### PR TITLE
chore: ignore local repo map artifact

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,7 @@ _witness_tmp/
 _dev_out/
 artifacts.zip
 artifacts_out/
+
+# local artifacts
+_repo_map.txt
+


### PR DESCRIPTION
Ignore _repo_map.txt (local artifact) to prevent accidental commits.