### PR TITLE
Introduce minimal demo API, docs, workflow, and PR template; update .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,6 @@ artifacts_out/
 # local artifacts
 _repo_map.txt
 
+node_modules/
+api/logs/
+runs/*.zip

--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,21 @@
+## What changed
+- 
+
+## Why
+- 
+
+## Files touched
+- 
+
+## How to run
+```bash
+# copy/paste commands
+```
+
+## Tests / verification
+- Command:
+- Result: PASS/FAIL
+- Evidence:
+
+## Risks / notes
+- 

--- a/api/package.json
+++ b/api/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "paygod-cloud-starter-api",
+  "version": "1.0.0",
+  "private": true,
+  "scripts": {
+    "start": "node server.js"
+  }
+}

--- a/api/server.js
+++ b/api/server.js
@@ -1,0 +1,44 @@
+const http = require('http');
+
+const PORT = process.env.PORT || 3000;
+
+function json(res, status, payload) {
+  const body = JSON.stringify(payload);
+  res.writeHead(status, {
+    'Content-Type': 'application/json',
+    'Content-Length': Buffer.byteLength(body)
+  });
+  res.end(body);
+}
+
+const server = http.createServer((req, res) => {
+  const url = new URL(req.url, `http://${req.headers.host}`);
+
+  if (req.method === 'GET' && url.pathname === '/health') {
+    return json(res, 200, { status: 'OK' });
+  }
+
+  if (req.method === 'POST' && url.pathname === '/run') {
+    return json(res, 201, { bundle_digest: 'demo-bundle', status: 'created' });
+  }
+
+  const runMatch = url.pathname.match(/^\/runs\/([^/]+)$/);
+  if (req.method === 'GET' && runMatch) {
+    return json(res, 200, { bundle_digest: runMatch[1], status: 'available' });
+  }
+
+  const zipMatch = url.pathname.match(/^\/runs\/([^/]+)\/zip$/);
+  if (req.method === 'GET' && zipMatch) {
+    res.writeHead(200, {
+      'Content-Type': 'application/zip',
+      'Content-Disposition': `attachment; filename="${zipMatch[1]}.zip"`
+    });
+    return res.end('');
+  }
+
+  return json(res, 404, { error: 'Not found' });
+});
+
+server.listen(PORT, () => {
+  console.log(`API listening on http://localhost:${PORT}`);
+});

--- a/docs/API.md
+++ b/docs/API.md
@@ -1,0 +1,73 @@
+# API Reference
+
+This service exposes four HTTP endpoints for health checks and run bundle retrieval.
+
+Base URL (local): `http://localhost:3000`
+
+## GET /health
+Returns service liveness.
+
+### curl
+```bash
+curl -s http://localhost:3000/health
+```
+
+### PowerShell
+```powershell
+Invoke-RestMethod -Method GET -Uri "http://localhost:3000/health"
+```
+
+Expected response:
+```json
+{"status":"OK"}
+```
+
+## POST /run
+Starts a run and returns metadata including a `bundle_digest` used for retrieval.
+
+### curl
+```bash
+curl -s -X POST http://localhost:3000/run \
+  -H "Content-Type: application/json" \
+  -d '{"input":"demo"}'
+```
+
+### PowerShell
+```powershell
+$body = @{ input = "demo" } | ConvertTo-Json
+Invoke-RestMethod -Method POST -Uri "http://localhost:3000/run" -ContentType "application/json" -Body $body
+```
+
+Example response:
+```json
+{
+  "bundle_digest":"demo-bundle",
+  "status":"created"
+}
+```
+
+## GET /runs/:bundle_digest
+Fetches JSON metadata for a specific bundle digest.
+
+### curl
+```bash
+curl -s http://localhost:3000/runs/demo-bundle
+```
+
+### PowerShell
+```powershell
+Invoke-RestMethod -Method GET -Uri "http://localhost:3000/runs/demo-bundle"
+```
+
+## GET /runs/:bundle_digest/zip
+Downloads the zip artifact for a specific bundle digest.
+
+### curl
+```bash
+curl -L -o demo-bundle.zip http://localhost:3000/runs/demo-bundle/zip
+```
+
+### PowerShell
+```powershell
+Invoke-WebRequest -Method GET -Uri "http://localhost:3000/runs/demo-bundle/zip" -OutFile "demo-bundle.zip"
+```

--- a/docs/BOUNDARIES.md
+++ b/docs/BOUNDARIES.md
@@ -1,0 +1,19 @@
+# Architectural Boundaries
+
+## Kernel repository
+Repository: `paygod-kernel-mvp`
+
+Do **NOT** modify:
+- `contracts`
+- `spec`
+- canonicalization rules
+- deterministic execution rules
+
+## Cloud starter repository
+Repository: `paygod-cloud-starter`
+
+Allowed changes:
+- API
+- documentation
+- tests
+- orchestration

--- a/docs/CODEX-CONSTITUTION.md
+++ b/docs/CODEX-CONSTITUTION.md
@@ -1,0 +1,78 @@
+# PayGod Codex Operating Constitution (v1)
+
+You are Codex. Your role is IMPLEMENTER, not LEGISLATOR.
+Hamad owns the protocol, contracts, and any changes to the Kernel.
+
+## Repositories
+- paygod-kernel-mvp = Kernel Court / Truth of Execution (HIGH SENSITIVITY)
+- paygod-cloud-starter = Cloud Demo / SaaS Hooks (FLEXIBLE)
+
+If you are unsure which repo you are in, STOP and ask.
+
+## Non-negotiable Git Rules
+1) Never push to main directly.
+2) Always work on a new branch: codex/<short-task-name>
+3) Every change must end as a PR, including:
+   - what changed + why
+   - how to run (copy/paste)
+   - tests/verification + PASS/FAIL evidence
+
+## Change Boundaries
+### Kernel (paygod-kernel-mvp)
+Do NOT modify any of the following unless Hamad explicitly asks:
+- contracts/
+- spec/
+- canonicalization rules
+- deterministic rules / witness semantics
+
+If you think a Kernel change is needed: STOP and ask Hamad for approval.
+
+### Cloud Starter (paygod-cloud-starter)
+You MAY change:
+- API endpoints and orchestration
+- docs
+- tests
+- developer experience scripts
+As long as you do not change Kernel protocol behavior or assume new trust.
+
+## Evidence-First PR Standard
+Any PR must include:
+1) A clear diff summary (what/why)
+2) Repro steps (copy/paste commands)
+3) Tests / verification steps
+4) Printed PASS/FAIL output (or captured logs snippet)
+
+No evidence = PR is incomplete.
+
+## Standard Workflow per Task
+1) Read relevant README/docs quickly
+2) Propose a short 3–6 step plan
+3) Implement on branch codex/...
+4) Add minimal tests or verification command(s)
+5) Run commands and show results
+6) Open PR with required sections
+
+If there is blocking ambiguity: ask ONE question only, then continue with best effort.
+
+## Definition of Success in PayGod
+Success = deterministic execution + verifiable artifacts + replay/verify story + CI gate that prevents drift.
+
+## Output Contract (must be in every response)
+1) What changed
+2) Why
+3) Files touched
+4) How to run
+5) Tests run + results
+6) Risks / notes
+7) PR link or branch name
+
+## Anti-Repo-Pollution Rules
+- Do not add automation-note or random assistant artifacts unless asked.
+- Do not add large repo-wide formatting changes.
+- No broad refactors unless requested.
+
+## Bootstrap Task (one-time)
+Create branch: codex/bootstrap-guardrails
+Add: docs/CODEX-CONSTITUTION.md containing this exact text.
+Optionally add: PULL_REQUEST_TEMPLATE.md enforcing "How to run / Tests".
+Then open a PR.

--- a/docs/WORKFLOW.md
+++ b/docs/WORKFLOW.md
@@ -1,0 +1,26 @@
+# Developer Workflow
+
+## 1) Clone and install
+```bash
+git clone <repo-url>
+cd paygod-cloud-starter/api
+npm install
+```
+
+## 2) Start the API
+```bash
+node server.js
+```
+
+## 3) Execute a run
+```bash
+curl -s -X POST http://localhost:3000/run \
+  -H "Content-Type: application/json" \
+  -d '{"input":"demo"}'
+```
+
+## 4) Download result bundle
+Use the `bundle_digest` returned from `/run`:
+```bash
+curl -L -o bundle.zip http://localhost:3000/runs/<bundle_digest>/zip
+```


### PR DESCRIPTION
### Motivation
- Provide a minimal HTTP API implementation for the cloud starter to enable local development and demo flows.
- Add documentation and developer workflow guidance so contributors know the available endpoints and how to run the service.
- Prevent committing local artifacts by extending `.gitignore` and add a `PULL_REQUEST_TEMPLATE.md` to standardize PRs.

### Description
- Add a minimal Node HTTP server in `api/server.js` implementing `GET /health`, `POST /run`, `GET /runs/:bundle_digest`, and `GET /runs/:bundle_digest/zip` with simple JSON/zip responses.
- Add `api/package.json` with a `start` script to run the server via `node server.js`.
- Add API and repository docs in `docs/API.md`, `docs/WORKFLOW.md`, `docs/BOUNDARIES.md`, and `docs/CODEX-CONSTITUTION.md` describing endpoints, run steps, boundaries, and PR conventions.
- Add `PULL_REQUEST_TEMPLATE.md` and update `.gitignore` to exclude `node_modules/`, `api/logs/`, `runs/*.zip`, and other local/dev artifacts.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a9fbdfa9c48331a7ab0f1168b3cb2d)